### PR TITLE
Update colors, typography and sizing

### DIFF
--- a/styles/buttons.ts
+++ b/styles/buttons.ts
@@ -12,7 +12,7 @@ export const bar: Record<Bar, ViewStyle> = {
     justifyContent: "center",
     padding: Sizing.layout.x30,
     borderRadius: Outlines.borderRadius.base,
-    backgroundColor: Colors.primary.s300,
+    backgroundColor: Colors.primary.brand,
   },
   secondary: {
     alignItems: "center",
@@ -33,7 +33,7 @@ export const barText: Record<BarText, TextStyle> = {
   secondary: {
     ...Typography.fontSize.x10,
     ...Typography.fontWeight.regular,
-    color: Colors.neutral.s100,
+    color: Colors.neutral.s500,
   },
 }
 
@@ -44,7 +44,7 @@ export const circular: Record<Circular, ViewStyle> = {
     width: Sizing.layout.x30,
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: Colors.primary.s300,
+    backgroundColor: Colors.primary.brand,
     borderRadius: Outlines.borderRadius.max,
   },
 }

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -1,47 +1,60 @@
-type Neutral = "white" | "s100" | "s300" | "s500" | "s700" | "s900" | "black"
+type Neutral =
+  | "white"
+  | "s100"
+  | "s150"
+  | "s200"
+  | "s250"
+  | "s300"
+  | "s400"
+  | "s500"
+  | "s600"
+  | "s700"
+  | "s800"
+  | "s900"
+  | "black"
 export const neutral: Record<Neutral, string> = {
   white: "#ffffff",
-  s100: "#e9eaf0",
-  s300: "#d6d6da",
-  s500: "#c5c5c9",
-  s700: "#3c475b",
-  s900: "#1c2537",
+  s100: "#efeff6",
+  s150: "#dfdfe6",
+  s200: "#c7c7ce",
+  s250: "#bbbbc2",
+  s300: "#9f9ea4",
+  s400: "#7c7c82",
+  s500: "#515154",
+  s600: "#38383a",
+  s700: "#2d2c2e",
+  s800: "#212123",
+  s900: "#161617",
   black: "#000000",
 }
 
-type Primary = "s100" | "s300"
+type Primary = "brand" | "s200" | "s600"
 export const primary: Record<Primary, string> = {
-  s100: "#4051db",
-  s300: "#4754c5",
+  s200: "#459de6",
+  brand: "#0d548f",
+  s600: "#0c3659",
 }
 
-type Secondary = "s100" | "s300"
+type Secondary = "brand" | "s200" | "s600"
 export const secondary: Record<Secondary, string> = {
-  s100: "#f8f8ff",
-  s300: "#e5e7fa",
+  s200: "#b968e8",
+  brand: "#591282",
+  s600: "#3f0d5c",
 }
 
-type Affordance =
-  | "danger10"
-  | "danger25"
-  | "success10"
-  | "success25"
-  | "warning10"
-  | "warning25"
-export const affordance: Record<Affordance, string> = {
-  danger10: "fff0f0",
-  danger25: "#ffe0e0",
-  success10: "#f2fcf4",
-  success25: "#deffe4",
-  warning10: "#f9edcc",
-  warning25: "#ffdc6f",
+type Danger = "s400"
+export const danger: Record<Danger, string> = {
+  s400: "#cf1717",
 }
 
-type Background = "primaryLight" | "primaryDark" | "secondaryLight"
-export const background: Record<Background, string> = {
-  primaryLight: neutral.white,
-  primaryDark: primary.s300,
-  secondaryLight: secondary.s100,
+type Success = "s400"
+export const success: Record<Success, string> = {
+  s400: "#008a09",
+}
+
+type Warning = "s400"
+export const warning: Record<Warning, string> = {
+  s400: "#cf9700",
 }
 
 const applyOpacity = (hexColor: string, opacity: number): string => {
@@ -52,8 +65,9 @@ const applyOpacity = (hexColor: string, opacity: number): string => {
   return `rgba(${red}, ${green}, ${blue}, ${opacity})`
 }
 
-type Overlay = "transparent" | "neutral30"
-export const overlay: Record<Overlay, string> = {
-  transparent: "rgba(255, 255, 255, 0)",
-  neutral30: applyOpacity(neutral.s300, 0.4),
+type Transparent = "clear" | "lightGray" | "darkGray"
+export const transparent: Record<Transparent, string> = {
+  clear: "rgba(255, 255, 255, 0)",
+  lightGray: applyOpacity(neutral.s300, 0.4),
+  darkGray: applyOpacity(neutral.s800, 0.8),
 }

--- a/styles/sizing.ts
+++ b/styles/sizing.ts
@@ -19,6 +19,15 @@ export const layout: Record<Layout, number> = {
   x70: 58,
 }
 
+export const x5 = layout.x5
+export const x10 = layout.x10
+export const x20 = layout.x20
+export const x30 = layout.x30
+export const x40 = layout.x40
+export const x50 = layout.x50
+export const x60 = layout.x60
+export const x70 = layout.x70
+
 type Icons = "x10" | "x20" | "x30" | "x40"
 export const icons: Record<Icons, number> = {
   x10: 14,

--- a/styles/typography.ts
+++ b/styles/typography.ts
@@ -1,7 +1,7 @@
 import { TextStyle } from "react-native"
 import { systemWeights } from "react-native-typography"
 
-type FontSize = "x10" | "x20" | "x30" | "x40" | "x50"
+type FontSize = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
 export const fontSize: Record<FontSize, TextStyle> = {
   x10: {
     fontSize: 13,
@@ -18,6 +18,9 @@ export const fontSize: Record<FontSize, TextStyle> = {
   x50: {
     fontSize: 32,
   },
+  x60: {
+    fontSize: 38,
+  },
 }
 
 type FontWeight = "regular" | "semibold" | "bold"
@@ -33,7 +36,7 @@ export const fontWeight: Record<FontWeight, TextStyle> = {
   },
 }
 
-type LineHeight = "x10" | "x20" | "x30" | "x40"
+type LineHeight = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
 export const lineHeight: Record<LineHeight, TextStyle> = {
   x10: {
     lineHeight: 12,
@@ -46,5 +49,47 @@ export const lineHeight: Record<LineHeight, TextStyle> = {
   },
   x40: {
     lineHeight: 26,
+  },
+  x50: {
+    lineHeight: 36,
+  },
+  x60: {
+    lineHeight: 48,
+  },
+}
+
+type Header = "x10" | "x20" | "x40" | "x50" | "x60"
+export const header: Record<Header, TextStyle> = {
+  x10: {
+    ...fontSize.x10,
+    ...lineHeight.x20,
+    ...fontWeight.bold,
+  },
+  x20: {
+    ...fontSize.x20,
+    ...lineHeight.x30,
+    ...fontWeight.semibold,
+  },
+  x40: {
+    ...fontSize.x40,
+    ...lineHeight.x40,
+    ...fontWeight.semibold,
+  },
+  x50: {
+    ...fontSize.x50,
+    ...lineHeight.x50,
+    ...fontWeight.bold,
+  },
+  x60: {
+    ...fontSize.x60,
+    ...lineHeight.x60,
+    ...fontWeight.bold,
+  },
+}
+
+type Body = "x10"
+export const body: Record<Body, TextStyle> = {
+  x10: {
+    ...fontSize.x10,
   },
 }


### PR DESCRIPTION
Why:
We would like to update our styles to be more useful for a typical
project. Currently we are missing some colors and typography styles.

This commit:
Adds some colors, typography for headers, and updates the api for the
common Sizing constants, .i.e. `Sizing.layout.x20` -> `Sizing.x20`

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>