### PR TITLE
Fix blog post link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ color: Colors.primary.blue
 ```
 
 Read the blog post, ["React Native Styling: Structure for Style Organization"][blog-post]
+
 [blog-post]: https://thoughtbot.com/blog/structure-for-styling-in-react-native
 
 About thoughtbot


### PR DESCRIPTION
Without the line break, the blog post link was not shown right.

![image](https://user-images.githubusercontent.com/28998674/104751008-b7571280-574c-11eb-98f5-8d3c22bd394b.png)

Fixed by adding the line break.